### PR TITLE
revised setup.py for non-Poetry installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
-# cli_read_write_csv
+# cli
 Basic Command-Line Interface (CLI) script that reads a local CSV and writes a modified version back to disk with a new name
+
+## Installation Instructions
+1. Obtain Code<BR>
+    a. Simple download….<BR>
+    b. git clone https://github.com/emskiphoto/cli.git
+2. Install Python
+3. Install pipx <BR>
+    Windows:  
+    `py -m pip install --user pipx`<BR>
+    `py -m pipx ensurepath`<BR>
+    Unix/macOS:<BR>
+    `python3 -m pip install --user pipx`<BR>
+    `python3 -m pipx ensurepath`<BR>
+4. `pipx install cli`
+
+
+## Usage
+$ cli 'data/test_file.csv'
 
 ## Background
 This repository is intended to be used as a template for development of CLI packages.  Main.py holds the primary code and is the entry point of the script.  Utils.py contains functions.  Config.py contains configuration items.  It includes a separate 'data' directory containing input data.  This repo has only been tested on Windows OS.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ readme = "README.md"
 
 [tool.poetry.scripts]
 cli = "cli.main:main"
+# note that Poetry installs will recognize this as the entry point for the package
+# but setuptools and others do not.  The current solution is to offer a setup.py for 
+# installs that don't use Poetry
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
 
-import setuptools
+from setuptools import setup
 
 if __name__ == "__main__":
-    setuptools.setup()
+    setup(name = 'cli',
+    version = '0.1.0',
+    packages = ['cli'],
+    entry_points = {
+        'console_scripts': [
+            'cli = cli.main:main'
+        ]
+    })


### PR DESCRIPTION
The previous build would not install without Poetry.  Additional parameters were added to setup.py files to support non-Poetry installs (ie., pipx).

Readme.md was updated with installation instructions.